### PR TITLE
Jw adjust root. Close #2

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  model(){
-    return this.get("store").findAll("reminder");
+  beforeModel(){
+    this.transitionTo("reminders")
   }
 });

--- a/app/routes/reminders.js
+++ b/app/routes/reminders.js
@@ -2,6 +2,6 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   model(){
-    return [1, 2, 3, 4, 5]
+    return this.get("store").findAll("reminder");
   }
 });

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,7 +1,1 @@
-{{#each model as |reminder|}}
-  <ul class='spec-reminder-item'>
-    <h2>{{reminder.title}}</h2>
-    <li>{{reminder.date}}</li>
-    <li>{{reminder.notes}}</li>
-  </ul>
-{{/each}}
+{{outlet}}

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -1,3 +1,7 @@
 {{#each model as |reminder|}}
-  <p>{{reminder}}</p>
+  <ul class='spec-reminder-item'>
+    <h2>{{reminder.title}}</h2>
+    <li>{{reminder.date}}</li>
+    <li>{{reminder.notes}}</li>
+  </ul>
 {{/each}}

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -13,7 +13,7 @@ test('viewing the homepage', function(assert) {
   visit('/');
 
   andThen(function() {
-    assert.equal(currentURL(), '/');
+    assert.equal(currentURL(), '/reminders');
     assert.equal(Ember.$('.spec-reminder-item').length, 5);
   });
 });


### PR DESCRIPTION
## Purpose

When a user visits the root page "/" they are now directed to "/reminders". 
[Issue #2](https://github.com/turingschool-projects/1610-remember-8/issues/2)

## Approach

When a user visits the root page "/" they are now directed to "/reminders". 

### Learning

Used the ember guide.
https://guides.emberjs.com/v2.5.0/routing/redirection/

### Test coverage 

Didn't write the test, but I did adjust the acceptance test to expect the "/reminders" route when visiting "/".

### Follow-up tasks

- [Issue #3](https://github.com/turingschool-projects/1610-remember-8/issues/3)

### Screenshots
#### Before
<img width="1221" alt="screen shot 2017-02-08 at 4 42 00 pm" src="https://cloud.githubusercontent.com/assets/20427352/22762844/a255e0f0-ee1e-11e6-9d64-8d0407881686.png">

#### After
<img width="1280" alt="screen shot 2017-02-08 at 4 42 09 pm" src="https://cloud.githubusercontent.com/assets/20427352/22762829/8af49b40-ee1e-11e6-95d4-7e8cdfbe9568.png">