### PR TITLE
Np visual cues CLOSES #15

### DIFF
--- a/app/components/edit-reminder.js
+++ b/app/components/edit-reminder.js
@@ -28,8 +28,10 @@ export default Ember.Component.extend({
       this.element.children[0].textContent = this.model.data.title;
       this.element.children[1].textContent = this.model.data.date;
       this.element.children[2].textContent = this.model.data.notes;
+      this.element.children[5].removeAttribute("hidden", 'true')
     },
     update(field, i){
+      this.element.children[5].removeAttribute("hidden")
       this.set(field, this.element.children[i].textContent)
     },
   }

--- a/app/components/new-reminder.js
+++ b/app/components/new-reminder.js
@@ -1,9 +1,10 @@
 import Ember from 'ember';
 export default Ember.Component.extend({
   store: Ember.inject.service(),
+
   actions: {
     submitReminder(){
-      this.getProperties("title", "date", "notes")
+      debugger;
       var date = new Date(this.getProperties("date").date.split("/"))
       return this.get("store").createRecord("reminder",{
         title: this.getProperties("title").title,

--- a/app/templates/components/edit-reminder.hbs
+++ b/app/templates/components/edit-reminder.hbs
@@ -5,3 +5,4 @@
   <button class="spec-save-button" {{action "save"}}>save</button>
 {{/link-to}}
 <button class="spec-reset-button" {{action "reset"}}>reset</button>
+<p class="spec-unsaved-text" hidden>You have unsaved changes</p>

--- a/app/templates/components/new-reminder.hbs
+++ b/app/templates/components/new-reminder.hbs
@@ -1,6 +1,6 @@
 <form class="new-reminder-form" action="index.html" method="post">
-  <input class="spec-input-title" type="text" value="" placeholder="title...">
-  <input class="spec-input-date" type="text" value="" placeholder="date...(mm/dd/yyyy)">
-  <input class="spec-input-notes" type="text" value="" placeholder="notes...">
+  {{input class="spec-input-title" type="text" value=title placeholder="title..."}}
+  {{input class="spec-input-date" type="text" value=date placeholder="date...(mm/dd/yyyy)"}}
+  {{input class="spec-input-notes" type="text" value=notes placeholder="notes..."}}
   <button {{action "submitReminder"}} class="spec-add-new">submit</button>
 </form>

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -117,3 +117,21 @@ test("clicking the reset button reverts reminder back to unsaved state", functio
       "after reset button is clicked, title is back to the original title")
   })
 })
+
+test("there is a visual cue if changes are being made", function(assert){
+  server.createList("reminder", 1);
+  visit("/reminders");
+  click(".spec-reminder-item:first");
+  andThen(function(){
+    click(".spec-edit-button")
+  })
+  andThen(function(){
+    assert.equal(find(".spec-unsaved-text").attr("hidden"), "hidden")
+    fillIn(".spec-edit-title", "test text test")
+    fillIn(".spec-edit-date", "01/28/1995");
+    fillIn(".spec-edit-notes", "Tis are test notez");
+  })
+  andThen(function(){
+    assert.equal(find(".spec-unsaved-text").text().trim(), "You have unsaved changes")
+  })
+})


### PR DESCRIPTION
## Purpose

The purpose of this PR is to display visual cues if there are unsaved changes when editing a reminder. https://github.com/turingschool-projects/1610-remember-8/issues/15

## Approach

It displays a p tag when the user is updating the data, we were able to put this in our existing update Action. Then when the save button is clicked, the p tag goes back to being hidden.


### Test coverage 

I wrote a test that made two assertions: one that the hidden attribute on the visual cue is true before the user starts editing, and a second one to test that there is text on the dom when changes are in progress.

### Screenshots
#### Before
<img width="1034" alt="screen shot 2017-02-15 at 3 01 39 pm" src="https://cloud.githubusercontent.com/assets/15061527/22997466/b499c67a-f38f-11e6-9fdb-db24106c049f.png">

#### After

<img width="900" alt="screen shot 2017-02-15 at 3 01 44 pm" src="https://cloud.githubusercontent.com/assets/15061527/22997470/b7d0f110-f38f-11e6-99e3-7550b035a47c.png">
