### PR TITLE
Delete reminders and closes #16

### DIFF
--- a/app/components/delete-reminder.js
+++ b/app/components/delete-reminder.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  store: Ember.inject.service(),
+
+  actions: {
+    delete(reminder){
+      debugger;
+      this.get("store").findRecord("reminder", this.reminder.id, {reload: true})
+      .then(function(record){
+        record.destroyRecord();
+      })
+    }
+  }
+});

--- a/app/components/delete-reminder.js
+++ b/app/components/delete-reminder.js
@@ -5,7 +5,6 @@ export default Ember.Component.extend({
 
   actions: {
     delete(reminder){
-      debugger;
       this.get("store").findRecord("reminder", this.reminder.id, {reload: true})
       .then(function(record){
         record.destroyRecord();

--- a/app/templates/components/delete-reminder.hbs
+++ b/app/templates/components/delete-reminder.hbs
@@ -1,0 +1,1 @@
+<button {{action "delete"}} class="delete-reminder">delete</button>

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -7,6 +7,7 @@
           class='spec-reminder-item'}}
         {{reminder.title}}
         {{/link-to}}
+        {{delete-reminder reminder=reminder}}
       </h2>
   {{/each}}
 {{else}}

--- a/app/templates/reminders/reminder/index.hbs
+++ b/app/templates/reminders/reminder/index.hbs
@@ -5,5 +5,5 @@
   <button>edit</button>
 {{/link-to}}
 {{#link-to "reminders"}}
-  {{delete-reminder reminder=model"}}
+  {{delete-reminder reminder=model}}
 {{/link-to}}

--- a/app/templates/reminders/reminder/index.hbs
+++ b/app/templates/reminders/reminder/index.hbs
@@ -4,3 +4,6 @@
 {{#link-to "reminders.reminder.edit" model class="spec-edit-button"}}
   <button>edit</button>
 {{/link-to}}
+{{#link-to "reminders"}}
+  {{delete-reminder reminder=model"}}
+{{/link-to}}

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -135,3 +135,22 @@ test("there is a visual cue if changes are being made", function(assert){
     assert.equal(find(".spec-unsaved-text").text().trim(), "You have unsaved changes")
   })
 })
+test("reminders can be deleted from the list page", function(assert){
+  server.createList("reminder", 1);
+  visit("/reminders");
+  click(".delete-reminder")
+  andThen(function(){
+    assert.equal(Ember.$(".spec-reminder-item").length, 0);
+  })
+})
+test("reminders can be deleted from the individual reminder page", function(assert){
+  server.createList("reminder", 5);
+  visit("/reminders")
+  click(".spec-reminder-item:first");
+  andThen(function(){
+    click(".delete-reminder")
+  })
+  andThen(function(){
+    assert.equal(Ember.$(".spec-reminder-item").length, 4)
+  })
+})


### PR DESCRIPTION
## Purpose

To delete reminders from the list view and individual pages
## Approach
We made a component that can be called in both hbs files for both pages, but made sure the models were called correctly

### Learning
well at first we made two different controllers that could be connected to the two different files we had made and we got it working through controller actions

#### Blog Posts

### Open Questions and Pre-Merge TODOs

- [ ] Use Github checklists. When solved, check the box and explain the answer.

### Test coverage 

I just wrote two assertion/acceptance tests to test the length for individual and list view

### Screenshots

#### Before

#### After